### PR TITLE
Switch to central package management with Directory.Packages.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <ItemGroup>
-        <PackageReference Include="Nerdbank.GitVersioning">
-            <Version>3.6.143</Version>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-    </ItemGroup>
-</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,43 @@
+﻿<Project>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+    <ItemGroup>
+        <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.7.115"/>
+    </ItemGroup>
+    <ItemGroup>
+        <PackageVersion Include="BlazorMonaco" Version="3.3.0"/>
+        <PackageVersion Include="ColorCode.HTML" Version="2.0.15"/>
+        <PackageVersion Include="coverlet.collector" Version="6.0.4">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageVersion>
+        <PackageVersion Include="HotChocolate.AspNetCore" Version="13.9.12"/>
+        <PackageVersion Include="HotChocolate.Data" Version="13.9.12"/>
+        <PackageVersion Include="HotChocolate.Types.Scalars" Version="13.9.12"/>
+        <PackageVersion Include="Macross.Json.Extensions" Version="3.0.0"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.8"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.8"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8"/>
+        <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1"/>
+        <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
+        <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.1"/>
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1"/>
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1"/>
+        <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1"/>
+        <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1"/>
+        <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.1"/>
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0"/>
+        <PackageVersion Include="Shouldly" Version="4.3.0"/>
+        <PackageVersion Include="System.CodeDom" Version="8.0.0"/>
+        <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>
+        <PackageVersion Include="System.Text.Json" Version="8.0.5"/>
+        <PackageVersion Include="TabBlazor" Version="0.8.1.1-alpha"/>
+        <PackageVersion Include="Websocket.Client" Version="5.1.2"/>
+        <PackageVersion Include="xunit" Version="2.9.3"/>
+        <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageVersion>
+    </ItemGroup>
+</Project>

--- a/Linq2GraphQL.sln
+++ b/Linq2GraphQL.sln
@@ -8,10 +8,10 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".items", ".items", "{7A8567FE-C13A-434E-AFA6-5A8F55F2C6B5}"
 	ProjectSection(SolutionItems) = preProject
 		.gitignore = .gitignore
-		Directory.Build.props = Directory.Build.props
 		nuget.config = nuget.config
 		README.md = README.md
 		version.json = version.json
+		Directory.Packages.props = Directory.Packages.props
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Linq2GraphQL.TestServer", "test\Linq2GraphQL.TestServer\Linq2GraphQL.TestServer.csproj", "{AD8291B6-5979-4C43-B785-EAD4FF93C564}"

--- a/docs/Linq2GraphQL.Docs/Linq2GraphQL.Docs.csproj
+++ b/docs/Linq2GraphQL.Docs/Linq2GraphQL.Docs.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
@@ -11,12 +11,12 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="System.Text.Json" Version="8.0.4" />
-		<PackageReference Include="BlazorMonaco" Version="3.2.0" />
-		<PackageReference Include="ColorCode.HTML" Version="2.0.15" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.8" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.8" PrivateAssets="all" />
-		<PackageReference Include="TabBlazor" Version="0.8.1.1-alpha" />
+		<PackageReference Include="System.Text.Json" />
+		<PackageReference Include="BlazorMonaco" />
+		<PackageReference Include="ColorCode.HTML" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" PrivateAssets="all" />
+		<PackageReference Include="TabBlazor" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -27,7 +27,7 @@
 	<Target Name="BuildClientAssets" AfterTargets="ComputeFilesToPublish">
 		<ItemGroup>
 			<DistFiles Include="Components\Samples\**\*.razor.cs" />
-			<ResolvedFileToPublish Include="@(DistFiles->'%(FullPath)')" Exclude="@(ResolvedFileToPublish)">
+			<ResolvedFileToPublish Include="@(DistFiles-&gt;'%(FullPath)')" Exclude="@(ResolvedFileToPublish)">
 				<RelativePath>wwwroot\_content\razor_samples\%(DistFiles.RecursiveDir)%(DistFiles.Filename)%(DistFiles.Extension)</RelativePath>
 				<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
 				<ExcludeFromSingleFile>true</ExcludeFromSingleFile>

--- a/src/Linq2GraphQL.Client.Subscriptions/Linq2GraphQL.Client.Subscriptions.csproj
+++ b/src/Linq2GraphQL.Client.Subscriptions/Linq2GraphQL.Client.Subscriptions.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
@@ -20,7 +20,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Websocket.Client" Version="5.1.2" />
+        <PackageReference Include="Websocket.Client" />
     </ItemGroup>
 
 </Project>

--- a/src/Linq2GraphQL.Client/Linq2GraphQL.Client.csproj
+++ b/src/Linq2GraphQL.Client/Linq2GraphQL.Client.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
@@ -15,8 +15,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
+        <PackageReference Include="Microsoft.Extensions.Http" />
     </ItemGroup>
 
 </Project>

--- a/src/Linq2GraphQL.Generator/Linq2GraphQL.Generator.csproj
+++ b/src/Linq2GraphQL.Generator/Linq2GraphQL.Generator.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -20,9 +20,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.CodeDom" Version="8.0.0" />
-        <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-        <PackageReference Include="Macross.Json.Extensions" Version="3.0.0" />
+        <PackageReference Include="System.CodeDom" />
+        <PackageReference Include="System.CommandLine" />
+        <PackageReference Include="Macross.Json.Extensions" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/Linq2GraphQL.Console/Linq2GraphQL.Console.csproj
+++ b/test/Linq2GraphQL.Console/Linq2GraphQL.Console.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,14 +7,14 @@
 
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="System.Text.Json" Version="8.0.4" />
-        <PackageReference Include="Websocket.Client" Version="5.1.2" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+        <PackageReference Include="System.Text.Json" />
+        <PackageReference Include="Websocket.Client" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" />
+        <PackageReference Include="Microsoft.Extensions.Logging" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     </ItemGroup>
     <ItemGroup>
       <ProjectReference Include="..\..\docs\StarWars.Client\StarWars.Client.csproj" />

--- a/test/Linq2GraphQL.TestServer.Shared/Linq2GraphQL.TestServer.Shared.csproj
+++ b/test/Linq2GraphQL.TestServer.Shared/Linq2GraphQL.TestServer.Shared.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="System.Text.Json" Version="8.0.4" />
-		<PackageReference Include="HotChocolate.AspNetCore" Version="13.9.12" />
-		<PackageReference Include="HotChocolate.Data" Version="13.9.12" />
+		<PackageReference Include="System.Text.Json" />
+		<PackageReference Include="HotChocolate.AspNetCore" />
+		<PackageReference Include="HotChocolate.Data" />
 	</ItemGroup>
 
 </Project>

--- a/test/Linq2GraphQL.TestServer/Linq2GraphQL.TestServer.csproj
+++ b/test/Linq2GraphQL.TestServer/Linq2GraphQL.TestServer.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -8,9 +8,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-		<PackageReference Include="System.Text.Json" Version="8.0.4" />
-        <PackageReference Include="HotChocolate.AspNetCore" Version="13.9.12" />
-        <PackageReference Include="HotChocolate.Data" Version="13.9.12" />
+		<PackageReference Include="System.Text.Json" />
+        <PackageReference Include="HotChocolate.AspNetCore" />
+        <PackageReference Include="HotChocolate.Data" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/Linq2GraphQL.TestServerNullable/Linq2GraphQL.TestServerNullable.csproj
+++ b/test/Linq2GraphQL.TestServerNullable/Linq2GraphQL.TestServerNullable.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
@@ -8,10 +8,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="System.Text.Json" Version="8.0.4" />
-		<PackageReference Include="HotChocolate.AspNetCore" Version="13.9.12" />
-		<PackageReference Include="HotChocolate.Data" Version="13.9.12" />
-		<PackageReference Include="HotChocolate.Types.Scalars" Version="13.9.12" />
+		<PackageReference Include="System.Text.Json" />
+		<PackageReference Include="HotChocolate.AspNetCore" />
+		<PackageReference Include="HotChocolate.Data" />
+		<PackageReference Include="HotChocolate.Types.Scalars" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/test/Linq2GraphQL.Tests/Linq2GraphQL.Tests.csproj
+++ b/test/Linq2GraphQL.Tests/Linq2GraphQL.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
@@ -10,25 +10,25 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.12.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-        <PackageReference Include="xunit" Version="2.9.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="Shouldly"/>
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.2">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Linq2GraphQL.TestClientNullable\Linq2GraphQL.TestClientNullable.csproj" />
-        <ProjectReference Include="..\Linq2GraphQL.TestClient\Linq2GraphQL.TestClient.csproj" />
-        <ProjectReference Include="..\Linq2GraphQL.TestServerNullable\Linq2GraphQL.TestServerNullable.csproj" />
-        <ProjectReference Include="..\Linq2GraphQL.TestServer\Linq2GraphQL.TestServer.csproj" />
+        <ProjectReference Include="..\Linq2GraphQL.TestClientNullable\Linq2GraphQL.TestClientNullable.csproj"/>
+        <ProjectReference Include="..\Linq2GraphQL.TestClient\Linq2GraphQL.TestClient.csproj"/>
+        <ProjectReference Include="..\Linq2GraphQL.TestServerNullable\Linq2GraphQL.TestServerNullable.csproj"/>
+        <ProjectReference Include="..\Linq2GraphQL.TestServer\Linq2GraphQL.TestServer.csproj"/>
     </ItemGroup>
 
 </Project>

--- a/test/Linq2GraphQL.Tests/MutationTests.cs
+++ b/test/Linq2GraphQL.Tests/MutationTests.cs
@@ -31,17 +31,13 @@ public class MutationTests : IClassFixture<SampleClientFixture>
         var id = Guid.NewGuid();
         var customerId = await sampleClient
             .Mutation
-            .AddCustomer(new CustomerInput
+            .AddCustomer(new()
             {
-                CustomerId = id,
-                CustomerName = "New Customer",
-                Orders = new List<OrderInput>(),
-                Status = CustomerStatus.Active,
+                CustomerId = id, CustomerName = "New Customer", Orders = new(), Status = CustomerStatus.Active
             })
-            .Select(e=> e.CustomerId)
+            .Select(e => e.CustomerId)
             .ExecuteAsync();
 
         Assert.Equal(id, customerId);
     }
-
 }

--- a/test/Linq2GraphQL.Tests/QueryArgumentTests.cs
+++ b/test/Linq2GraphQL.Tests/QueryArgumentTests.cs
@@ -1,112 +1,104 @@
 ﻿using Linq2GraphQL.TestClient;
 
-namespace Linq2GraphQL.Tests
+namespace Linq2GraphQL.Tests;
+
+public class QueryArgumentTests : IClassFixture<SampleClientFixture>
 {
+    private readonly SampleClient sampleClient;
 
-    public class QueryArgumentTests : IClassFixture<SampleClientFixture>
+    public QueryArgumentTests(SampleClientFixture safeModeClient)
     {
-        private readonly SampleClient sampleClient;
-
-        public QueryArgumentTests(SampleClientFixture safeModeClient)
-        {
-            sampleClient = safeModeClient.sampleClient;
-        }
-
-        [Fact]
-        public async Task TopAndInQueryArguments_SameName()
-        {
-            var query = sampleClient
-                .Query
-                .Orders(first: 1)
-                .Include(e => e.Nodes.Select(e => e.OrderHello("JOcke", 2)))
-                .Include(e => e.Nodes.Select(e => e.OrderAddress(AddressType.Invoice)))
-                .Select(e => e.Nodes);
-
-            var request = await query.GetRequestAsync();
-            var result = await query.ExecuteAsync();
-
-            Assert.Single(result);
-        }
-
-        [Fact]
-        public async Task TopLevelArguments()
-        {
-            var query = sampleClient
-                .Query
-                .Orders(first: 1)
-                .Select(e => e.Nodes);
-
-            var request = await query.GetRequestAsync();
-            var result = await query.ExecuteAsync();
-
-            var order = result.First();
-
-            var address = order.OrderAddress;
-
-            Assert.Single(result);
-        }
-
-        [Fact]
-        public async Task InQueryArguments()
-        {
-            var query = sampleClient
-                .Query
-                .Orders(first: 1)
-                .Include(e => e.Nodes.Select(e => e.OrderAddress(AddressType.Invoice)))
-                .Select(e => e.Nodes);
-
-            var request = query.GetRequestAsync();
-
-            var result = await query.ExecuteAsync();
-
-            var order = result.First();
-
-            Assert.NotNull(order.OrderAddress);
-            Assert.Equal("Invoice", result.First().OrderAddress?.Name);
-        }
-
-        [Fact]
-        public async Task InQueryAnonymousType()
-        {
-            var query = sampleClient
-                .Query
-                .Orders(first: 2)
-                .Include(e => e.Nodes)
-                .Select(e => e.Nodes.Select(e => e.OrderHello("Kalle", 123)));
-
-            var gQ = await query.GetRequestAsync();
-
-            var node = query.QueryNode;
-            var result = await query.ExecuteAsync();
-
-            Assert.NotNull(result.First());
-
-        }
-
-        [Fact]
-        public async Task InQueryArguments_Multiple()
-        {
-            var query = sampleClient
-                .Query
-                .Orders()
-                .Select(e => e.Nodes.Select(f => new
-                {
-                    Jocke = f.OrderHello("Jocke", 22),
-                    Kalle = f.OrderHello("Kalle", 11)
-                })
-                );
-
-            var request = query.GetRequestAsync();
-            var result = await query.ExecuteAsync();
-
-            var addresses = result.First();
-
-            Assert.Equal("Hello, Jocke [22]", addresses.Jocke);
-            Assert.Equal("Hello, Kalle [11]", addresses.Kalle);
-
-        }
-
-
+        sampleClient = safeModeClient.sampleClient;
     }
 
+    [Fact]
+    public async Task TopAndInQueryArguments_SameName()
+    {
+        var query = sampleClient
+            .Query
+            .Orders(1)
+            .Include(e => e.Nodes.Select(e => e.OrderHello("JOcke", 2)))
+            .Include(e => e.Nodes.Select(e => e.OrderAddress(AddressType.Invoice)))
+            .Select(e => e.Nodes);
+
+        var request = await query.GetRequestAsync();
+        var result = await query.ExecuteAsync();
+
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task TopLevelArguments()
+    {
+        var query = sampleClient
+            .Query
+            .Orders(1)
+            .Select(e => e.Nodes);
+
+        var request = await query.GetRequestAsync();
+        var result = await query.ExecuteAsync();
+
+        var order = result.First();
+
+        var address = order.OrderAddress;
+
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task InQueryArguments()
+    {
+        var query = sampleClient
+            .Query
+            .Orders(1)
+            .Include(e => e.Nodes.Select(e => e.OrderAddress(AddressType.Invoice)))
+            .Select(e => e.Nodes);
+
+        var request = query.GetRequestAsync();
+
+        var result = await query.ExecuteAsync();
+
+        var order = result.First();
+
+        Assert.NotNull(order.OrderAddress);
+        Assert.Equal("Invoice", result.First().OrderAddress?.Name);
+    }
+
+    [Fact]
+    public async Task InQueryAnonymousType()
+    {
+        var query = sampleClient
+            .Query
+            .Orders(2)
+            .Include(e => e.Nodes)
+            .Select(e => e.Nodes.Select(e => e.OrderHello("Kalle", 123)));
+
+        var gQ = await query.GetRequestAsync();
+
+        var node = query.QueryNode;
+        var result = await query.ExecuteAsync();
+
+        Assert.NotNull(result.First());
+    }
+
+    [Fact]
+    public async Task InQueryArguments_Multiple()
+    {
+        var query = sampleClient
+            .Query
+            .Orders()
+            .Select(e => e.Nodes.Select(f => new
+                {
+                    Jocke = f.OrderHello("Jocke", 22), Kalle = f.OrderHello("Kalle", 11)
+                })
+            );
+
+        var request = query.GetRequestAsync();
+        var result = await query.ExecuteAsync();
+
+        var addresses = result.First();
+
+        Assert.Equal("Hello, Jocke [22]", addresses.Jocke);
+        Assert.Equal("Hello, Kalle [11]", addresses.Kalle);
+    }
 }

--- a/test/Linq2GraphQL.Tests/QueryIncludeTests.cs
+++ b/test/Linq2GraphQL.Tests/QueryIncludeTests.cs
@@ -1,5 +1,4 @@
-﻿using HotChocolate.Execution;
-using Linq2GraphQL.TestClient;
+﻿using Linq2GraphQL.TestClient;
 
 namespace Linq2GraphQL.Tests;
 
@@ -32,7 +31,7 @@ public class QueryIncludeTests : IClassFixture<SampleClientFixture>
     {
         var query = sampleClient
             .Query
-            .Orders(first: 1)
+            .Orders(1)
             .Include(e => e.Nodes.Select(e => e.Customer))
             .Include(e => e.Nodes.Select(e => e.Customer.Orders))
             .Select(e => e.Nodes);
@@ -62,11 +61,7 @@ public class QueryIncludeTests : IClassFixture<SampleClientFixture>
                 Hello = n.OrderHello("Peter", 1234),
                 DeliveryAddress = n.OrderAddress(AddressType.Delivery),
                 InvoiceAddress = n.OrderAddress(AddressType.Invoice),
-                Cust = new
-                {
-                    n.Customer.CustomerName,
-                    n.Customer.Orders
-                }
+                Cust = new { n.Customer.CustomerName, n.Customer.Orders }
             }));
 
         var q = await query.GetRequestAsync();
@@ -92,19 +87,9 @@ public class QueryIncludeTests : IClassFixture<SampleClientFixture>
             .Query
             .Orders(where: new()
             {
-                Customer = new()
-                {
-                    CustomerId = new()
-                    {
-                        Eq = Guid.Parse("3b1761fb-6551-404e-80b0-a6c12f298a06")
-                    }
-                }
+                Customer = new() { CustomerId = new() { Eq = Guid.Parse("3b1761fb-6551-404e-80b0-a6c12f298a06") } }
             })
-            .Select(e => e.Nodes.Select(n => new
-            {
-                n.Customer,
-                n.Customer.Orders
-            }))
+            .Select(e => e.Nodes.Select(n => new { n.Customer, n.Customer.Orders }))
             .ExecuteAsync();
 
 

--- a/test/Linq2GraphQL.Tests/QueryInterfaceTests.cs
+++ b/test/Linq2GraphQL.Tests/QueryInterfaceTests.cs
@@ -1,59 +1,50 @@
 ﻿using Linq2GraphQL.TestClient;
 
-namespace Linq2GraphQL.Tests
+namespace Linq2GraphQL.Tests;
+
+public class QueryInterfaceTests : IClassFixture<SampleClientFixture>
 {
+    private readonly SampleClient sampleClient;
 
-    public class QueryInterfaceTests : IClassFixture<SampleClientFixture>
+    public QueryInterfaceTests(SampleClientFixture safeModeClient)
     {
-        private readonly SampleClient sampleClient;
-
-        public QueryInterfaceTests(SampleClientFixture safeModeClient)
-        {
-            sampleClient = safeModeClient.sampleClient;
-        }
-
-        [Fact]
-        public async Task Interface_NoSubclass()
-        {
-            var result = await sampleClient
-                .Query
-                .Animals()
-                .Select(e => e.Nodes)
-                .ExecuteAsync();
-
-            var pig = result.First();
-            var spider = result.Last();
-
-            Assert.IsType<Spider>(spider);
-            Assert.IsType<Pig>(pig);
-
-        }
-
-        [Fact]
-        public async Task Interface_QuerySubClass()
-        {
-            var query = sampleClient
-                .Query
-                .Animals()
-                .Include(e => e.Nodes.Select(e => e.Pig()))
-                .Include(e => e.Nodes.Select(e => e.Spider()))
-                .Select(e => e.Nodes);
-
-
-            var request = await query.GetRequestAsync();
-            var result = await query.ExecuteAsync();
-
-            var pig = result.First();
-            var spider = result.Last();
-
-            Assert.IsType<Spider>(spider);
-            Assert.IsType<Pig>(pig);
-
-
-        }
-
-    
-
+        sampleClient = safeModeClient.sampleClient;
     }
 
+    [Fact]
+    public async Task Interface_NoSubclass()
+    {
+        var result = await sampleClient
+            .Query
+            .Animals()
+            .Select(e => e.Nodes)
+            .ExecuteAsync();
+
+        var pig = result.First();
+        var spider = result.Last();
+
+        Assert.IsType<Spider>(spider);
+        Assert.IsType<Pig>(pig);
+    }
+
+    [Fact]
+    public async Task Interface_QuerySubClass()
+    {
+        var query = sampleClient
+            .Query
+            .Animals()
+            .Include(e => e.Nodes.Select(e => e.Pig()))
+            .Include(e => e.Nodes.Select(e => e.Spider()))
+            .Select(e => e.Nodes);
+
+
+        var request = await query.GetRequestAsync();
+        var result = await query.ExecuteAsync();
+
+        var pig = result.First();
+        var spider = result.Last();
+
+        Assert.IsType<Spider>(spider);
+        Assert.IsType<Pig>(pig);
+    }
 }

--- a/test/Linq2GraphQL.Tests/QueryNullableTests.cs
+++ b/test/Linq2GraphQL.Tests/QueryNullableTests.cs
@@ -1,73 +1,68 @@
-﻿using Linq2GraphQL.TestClient;
+﻿using System.Text;
 using Linq2GraphQL.TestClientNullable;
-using System.Collections;
-using System.Text;
 
+namespace Linq2GraphQL.Tests;
 
-namespace Linq2GraphQL.Tests
+public class QueryNullableTests : IClassFixture<SampleNullableClientFixture>
 {
-    public class QueryNullableTests : IClassFixture<SampleNullableClientFixture>
+    private readonly SampleNullableClient nullableClient;
+
+    public QueryNullableTests(SampleNullableClientFixture nullableFixture)
     {
-        private readonly SampleNullableClient nullableClient;
+        nullableClient = nullableFixture.sampleClient;
+    }
 
-        public QueryNullableTests(SampleNullableClientFixture nullableFixture)
-        {
-            nullableClient = nullableFixture.sampleClient;
-        }
+    [Fact]
+    public async Task GetCustomers()
+    {
+        var result = await nullableClient
+            .Query
+            .CustomerList()
+            .Select()
+            .ExecuteAsync();
 
-        [Fact]
-        public async Task GetCustomers()
-        {
-            var result = await nullableClient
-                .Query
-                .CustomerList()
-                .Select()
-                .ExecuteAsync();
+        Assert.Equal(2, result.Count);
+    }
 
-            Assert.Equal(2, result.Count);
-        }
+    [Fact]
+    public async Task GetItemData()
+    {
+        var result = await nullableClient
+            .Query
+            .Item()
+            .Include(e => e.Data)
+            .Select()
+            .ExecuteAsync();
 
-        [Fact]
-        public async Task GetItemData()
-        {
-            var result = await nullableClient
-                .Query
-                .Item()
-                .Include(e=> e.Data)
-                .Select()
-                .ExecuteAsync();
+        var data = Encoding.UTF8.GetString(result.Data!.ToArray());
 
-            var data = System.Text.Encoding.UTF8.GetString(result.Data!.ToArray());
-
-            Assert.Equal(result.ItemName, data);
-        }
+        Assert.Equal(result.ItemName, data);
+    }
 
 
-        [Fact]
-        public async Task GetCustomerNull()
-        {
-            var result = await nullableClient
-                .Query
-                .CustomerNullable()
-                .Select()
-                .ExecuteAsync();
+    [Fact]
+    public async Task GetCustomerNull()
+    {
+        var result = await nullableClient
+            .Query
+            .CustomerNullable()
+            .Select()
+            .ExecuteAsync();
 
-            Assert.Null(result);
-        }
+        Assert.Null(result);
+    }
 
 
-        [Fact]
-        public async Task GetCustomerListInList()
-        {
-            var result = await nullableClient
-                .Query
-                .CustomerListInList()
-                .Select()
-                .ExecuteAsync();
+    [Fact]
+    public async Task GetCustomerListInList()
+    {
+        var result = await nullableClient
+            .Query
+            .CustomerListInList()
+            .Select()
+            .ExecuteAsync();
 
-            TestClientNullable.Customer? customer = result.FirstOrDefault()?.FirstOrDefault();
-            Assert.NotNull(customer);
-        }
-
+        var customer = result.FirstOrDefault()?.FirstOrDefault();
+        Assert.NotNull(customer);
     }
 }

--- a/test/Linq2GraphQL.Tests/QueryPagingTests.cs
+++ b/test/Linq2GraphQL.Tests/QueryPagingTests.cs
@@ -1,7 +1,3 @@
-using FluentAssertions;
-using GreenDonut;
-using HotChocolate.Types.Pagination;
-using Linq2GraphQL.Client;
 using Linq2GraphQL.TestClient;
 
 namespace Linq2GraphQL.Tests;
@@ -15,14 +11,13 @@ public class QueryPagingTests : IClassFixture<SampleClientFixture>
         this.sampleClient = sampleClient.sampleClient;
     }
 
-  
 
     [Fact]
     public async Task Orders_ManualPaging()
     {
         var query = sampleClient
             .Query
-            .OrdersNoBackwardPagination(first: 2)
+            .OrdersNoBackwardPagination(2)
             .Include(e => e.Nodes)
             .Include(e => e.PageInfo)
             .Include(e => e.TotalCount)
@@ -30,11 +25,11 @@ public class QueryPagingTests : IClassFixture<SampleClientFixture>
 
         var request = await query.GetRequestAsync();
 
-      await query.ExecuteBaseAsync();
+        await query.ExecuteBaseAsync();
 
         var result1 = query.ConvertResult(query.BaseResult);
         var result2 = result1;
-       
+
         if (query.BaseResult.PageInfo.HasNextPage)
         {
             query.QueryNode.SetArgumentValue("after", query.BaseResult.PageInfo.EndCursor);
@@ -42,21 +37,19 @@ public class QueryPagingTests : IClassFixture<SampleClientFixture>
         }
 
         Assert.NotEqual(result1.First().OrderId, result2.First().OrderId);
-
     }
 
     [Fact]
     public async Task Orders_NotIncludeTotalCount()
     {
         var query = sampleClient
-         .Query
-         .Orders()
-         .Select(e => e.Nodes);
+            .Query
+            .Orders()
+            .Select(e => e.Nodes);
 
         var result = await query.ExecuteAsync();
-        
-        Assert.Equal(0, query.BaseResult.TotalCount);
 
+        Assert.Equal(0, query.BaseResult.TotalCount);
     }
 
 
@@ -64,25 +57,20 @@ public class QueryPagingTests : IClassFixture<SampleClientFixture>
     public async Task Orders_Paging()
     {
         var pager = sampleClient
-         .Query
-         .Orders()
-         .Include(e => e.TotalCount)
-         //.Include(e => e.Nodes.Select(e => e.Customer.Orders))
-
-         .Select(e => e.Nodes.Select(e => new { e.OrderId }))
-         .AsPager();
+            .Query
+            .Orders()
+            .Include(e => e.TotalCount)
+            //.Include(e => e.Nodes.Select(e => e.Customer.Orders))
+            .Select(e => e.Nodes.Select(e => new { e.OrderId }))
+            .AsPager();
 
         var firstPage = await pager.NextPageAsync();
-         var totalCount = pager.PagerResult.TotalCount;
+        var totalCount = pager.PagerResult.TotalCount;
         var secondPage = await pager.NextPageAsync();
         var firstPageAgain = await pager.PreviousPageAsync();
 
 
         Assert.NotEqual(firstPage.First().OrderId, secondPage.First().OrderId);
         Assert.Equal(firstPage.First().OrderId, firstPageAgain.First().OrderId);
-
     }
-
-
-
 }

--- a/test/Linq2GraphQL.Tests/QueryProjectionTests.cs
+++ b/test/Linq2GraphQL.Tests/QueryProjectionTests.cs
@@ -1,98 +1,88 @@
 ﻿using Linq2GraphQL.TestClient;
 
-namespace Linq2GraphQL.Tests
+namespace Linq2GraphQL.Tests;
+
+public class QueryProjectionTests : IClassFixture<SampleClientFixture>
 {
+    private readonly SampleClient sampleClient;
 
-    public class QueryProjectionTests : IClassFixture<SampleClientFixture>
+    public QueryProjectionTests(SampleClientFixture safeModeClient)
     {
-        private readonly SampleClient sampleClient;
+        sampleClient = safeModeClient.sampleClient;
+    }
 
-        public QueryProjectionTests(SampleClientFixture safeModeClient)
-        {
-            sampleClient = safeModeClient.sampleClient;
-        }
+    [Fact]
+    public async Task ProjectingAnomousObject()
+    {
+        var query = sampleClient
+            .Query
+            .Orders()
+            .Select(e => e.Nodes.Select(o => new OrderIdAddress { OrderId = o.OrderId, Address = o.Address }));
 
-        [Fact]
-        public async Task ProjectingAnomousObject()
-        {
-            var query = sampleClient
-                .Query
-                .Orders()
-                .Select(e => e.Nodes.Select(o => new OrderIdAddress { OrderId = o.OrderId, Address = o.Address }));
+        var request = await query.GetRequestAsync();
+        var result = await query.ExecuteAsync();
+        Assert.NotEqual(Guid.Empty, result.First().OrderId);
+        Assert.NotNull(result.First().Address);
 
-            var request = await query.GetRequestAsync();
-            var result = await query.ExecuteAsync();
-            Assert.NotEqual(Guid.Empty, result.First().OrderId);
-            Assert.NotNull(result.First().Address);
-           
-            var baseOrder = query.BaseResult.Nodes.First();
-            Assert.Null(baseOrder.Customer);
-            Assert.Equal(DateTimeOffset.MinValue, baseOrder.OrderDate);
+        var baseOrder = query.BaseResult.Nodes.First();
+        Assert.Null(baseOrder.Customer);
+        Assert.Equal(DateTimeOffset.MinValue, baseOrder.OrderDate);
+    }
 
-        }
-
-        [Fact]
-        public async Task ProjectingToType()
-        {
-            var query = sampleClient
+    [Fact]
+    public async Task ProjectingToType()
+    {
+        var query = sampleClient
                 .Query
                 .Orders()
                 .Select(e => e.Nodes.Select(o => new OrderIdAddress { OrderId = o.OrderId, Address = o.Address }))
-               ;
-
-      
-            var result = await query.ExecuteAsync();
-            var order = result.First();
-            Assert.NotEqual(Guid.Empty, order.OrderId);
-            Assert.NotNull(order.Address);
-
-            var baseOrder = query.BaseResult.Nodes.First();
-            Assert.Null(baseOrder.Customer);
-            Assert.Equal(DateTimeOffset.MinValue, baseOrder.OrderDate);
-
-        }
-
-        [Fact]
-        public async Task Project_SelectMany()
-        {
-            var query = sampleClient
-                .Query
-                .Customers()
-                .Select(e => e.SelectMany(e=> e.Orders));
-
-            var result = await query.ExecuteAsync();
-        
-
-            Assert.True(result.All(e=> e.OrderId != default));
-
-        }
-
-      
-        [Fact]
-        public async Task Project_TopLevelAllPrimitive()
-        {
-
-            var query = sampleClient
-                .Query
-                .Customers()
-                .Include()
-                .Select(e => new { Customers = e, Orders = e.SelectMany(f => f.Orders) });
-
-            var request = await query.GetRequestAsync();
-            var result = await query.ExecuteAsync();
-            var t = result.Customers.All(e => e.CustomerId != default);
-
-            Assert.True(result.Customers.All(e => e.CustomerId != default));
-
-        }
+            ;
 
 
+        var result = await query.ExecuteAsync();
+        var order = result.First();
+        Assert.NotEqual(Guid.Empty, order.OrderId);
+        Assert.NotNull(order.Address);
+
+        var baseOrder = query.BaseResult.Nodes.First();
+        Assert.Null(baseOrder.Customer);
+        Assert.Equal(DateTimeOffset.MinValue, baseOrder.OrderDate);
     }
 
-    public class  OrderIdAddress 
+    [Fact]
+    public async Task Project_SelectMany()
     {
-        public Guid OrderId { get; set; }
-        public Address? Address { get; set; }
+        var query = sampleClient
+            .Query
+            .Customers()
+            .Select(e => e.SelectMany(e => e.Orders));
+
+        var result = await query.ExecuteAsync();
+
+
+        Assert.True(result.All(e => e.OrderId != default));
     }
 
+
+    [Fact]
+    public async Task Project_TopLevelAllPrimitive()
+    {
+        var query = sampleClient
+            .Query
+            .Customers()
+            .Include()
+            .Select(e => new { Customers = e, Orders = e.SelectMany(f => f.Orders) });
+
+        var request = await query.GetRequestAsync();
+        var result = await query.ExecuteAsync();
+        var t = result.Customers.All(e => e.CustomerId != default);
+
+        Assert.True(result.Customers.All(e => e.CustomerId != default));
+    }
+}
+
+public class OrderIdAddress
+{
+    public Guid OrderId { get; set; }
+    public Address? Address { get; set; }
 }

--- a/test/Linq2GraphQL.Tests/QueryTests.cs
+++ b/test/Linq2GraphQL.Tests/QueryTests.cs
@@ -1,5 +1,5 @@
-using FluentAssertions;
 using Linq2GraphQL.TestClient;
+using Shouldly;
 
 namespace Linq2GraphQL.Tests;
 
@@ -59,7 +59,7 @@ public class QueryTests : IClassFixture<SampleClientFixture>
         var query = sampleClient
             .Query
             .Customers()
-            .Include(e => e.Select(e=> new { e.CustomerId, e.Status }))
+            .Include(e => e.Select(e => new { e.CustomerId, e.Status }))
             .Select();
 
         var result = await query.ExecuteAsync();
@@ -69,7 +69,6 @@ public class QueryTests : IClassFixture<SampleClientFixture>
         var customer1 = result[0];
         Assert.NotEqual(default, customer1.CustomerId);
         Assert.Equal(default, customer1.CustomerName);
-
     }
 
 
@@ -81,7 +80,7 @@ public class QueryTests : IClassFixture<SampleClientFixture>
             .Customers()
             .Include(e => e.Select(e => e.Orders))
             .Select();
-          
+
         var result = await query.ExecuteAsync();
 
         var customer1 = result[0];
@@ -110,7 +109,6 @@ public class QueryTests : IClassFixture<SampleClientFixture>
             .Customers()
             .Include(e => e.Select(e => e.Orders.Select(f => f.Address)))
             .Include(e => e.Select(e => e.Orders.Select(f => f.Customer)))
-           
             .Select()
             .ExecuteAsync();
 
@@ -138,7 +136,6 @@ public class QueryTests : IClassFixture<SampleClientFixture>
         Assert.NotNull(order.Customer?.CustomerName);
         Assert.Equal(default, order.Customer.CustomerId);
     }
-
 
     [Fact]
     public async Task Customers_WithSingleSelect()
@@ -182,7 +179,6 @@ public class QueryTests : IClassFixture<SampleClientFixture>
     }
 
 
-
     [Fact]
     public async Task Orders_WithSelectIncludeNodes()
     {
@@ -221,7 +217,6 @@ public class QueryTests : IClassFixture<SampleClientFixture>
         var baseType = query.BaseResult;
 
         Assert.Equal(default, baseType.Nodes.First().OrderDate);
-
     }
 
 
@@ -238,7 +233,6 @@ public class QueryTests : IClassFixture<SampleClientFixture>
         var orderAddresses = result.SelectMany(e => e.Customer.Orders.Select(a => a.Address));
 
         Assert.True(orderAddresses.All(e => e != null));
-
     }
 
     [Fact]
@@ -246,15 +240,12 @@ public class QueryTests : IClassFixture<SampleClientFixture>
     {
         var result = await sampleClient
             .Query
-            .Orders(order: new List<OrderSortInput> { new() { OrderDate = SortEnumType.Desc } })
+            .Orders(order: new() { new() { OrderDate = SortEnumType.Desc } })
             .Select(e => e.Nodes)
             .ExecuteAsync();
 
-        result.Should().BeInDescendingOrder(e => e.OrderDate);
+        result.OrderByDescending(x => x.OrderDate).ShouldBe(result);
     }
-
-  
-
 
     [Fact]
     public async Task QueryReturnNull_Object()
@@ -266,7 +257,6 @@ public class QueryTests : IClassFixture<SampleClientFixture>
             .ExecuteAsync();
 
         Assert.True(result == null);
-
     }
 
     [Fact]
@@ -279,7 +269,6 @@ public class QueryTests : IClassFixture<SampleClientFixture>
             .ExecuteAsync();
 
         Assert.True(result == null);
-
     }
 
     [Fact]
@@ -292,7 +281,6 @@ public class QueryTests : IClassFixture<SampleClientFixture>
             .ExecuteAsync();
 
         Assert.True(result == Guid.Empty);
-
     }
 
     [Fact]
@@ -305,7 +293,5 @@ public class QueryTests : IClassFixture<SampleClientFixture>
             .ExecuteAsync();
 
         Assert.True(result == null);
-
     }
-
 }

--- a/test/Linq2GraphQL.Tests/SampleClientFixture.cs
+++ b/test/Linq2GraphQL.Tests/SampleClientFixture.cs
@@ -14,15 +14,17 @@ public class SampleClientFixture : IDisposable
         var baseAddress = new Uri("https://localhost:7184/graphql/");
 
         var application = new WebApplicationFactory<Program>();
-        var client = application.CreateClient(new WebApplicationFactoryClientOptions { BaseAddress = baseAddress });
+        var client = application.CreateClient(new() { BaseAddress = baseAddress });
 
-        sampleClient = new SampleClient(client, Options.Create(new GraphClientOptions
-        {
-            SubscriptionProtocol = SubscriptionProtocol.ServerSentEvents,
-            UseSafeMode = true
-        }), application.Services);
+        sampleClient = new(client,
+            Options.Create(new GraphClientOptions
+            {
+                SubscriptionProtocol = SubscriptionProtocol.ServerSentEvents, UseSafeMode = true
+            }), application.Services);
         //Please note currently only ServerSentEvents work in test project
     }
 
-    public void Dispose() { }
+    public void Dispose()
+    {
+    }
 }

--- a/test/Linq2GraphQL.Tests/SampleClientNullableFixture.cs
+++ b/test/Linq2GraphQL.Tests/SampleClientNullableFixture.cs
@@ -1,5 +1,4 @@
 ﻿using Linq2GraphQL.Client;
-using Linq2GraphQL.TestClient;
 using Linq2GraphQL.TestClientNullable;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Options;
@@ -15,15 +14,17 @@ public class SampleNullableClientFixture : IDisposable
         var baseAddress = new Uri("https://localhost:50741/graphql/");
 
         var application = new WebApplicationFactory<ProgramNullable>();
-        var client = application.CreateClient(new WebApplicationFactoryClientOptions { BaseAddress = baseAddress });
+        var client = application.CreateClient(new() { BaseAddress = baseAddress });
 
-        sampleClient = new SampleNullableClient(client, Options.Create(new GraphClientOptions
-        {
-            SubscriptionProtocol = SubscriptionProtocol.ServerSentEvents,
-            UseSafeMode = false,
-        }), application.Services);
+        sampleClient = new(client,
+            Options.Create(new GraphClientOptions
+            {
+                SubscriptionProtocol = SubscriptionProtocol.ServerSentEvents, UseSafeMode = false
+            }), application.Services);
         //Please note currently only ServerSentEvents work in test project
     }
 
-    public void Dispose() { }
+    public void Dispose()
+    {
+    }
 }

--- a/test/Linq2GraphQL.Tests/ScalarTests.cs
+++ b/test/Linq2GraphQL.Tests/ScalarTests.cs
@@ -1,50 +1,42 @@
-﻿using Linq2GraphQL.TestClient;
-using Linq2GraphQL.TestClientNullable;
+﻿using Linq2GraphQL.TestClientNullable;
 
+namespace Linq2GraphQL.Tests;
 
-namespace Linq2GraphQL.Tests
+public class ScalarTests : IClassFixture<SampleNullableClientFixture>
 {
+    private readonly SampleNullableClient sampleClient;
 
-
-
-    public class ScalarTests : IClassFixture<SampleNullableClientFixture>
+    public ScalarTests(SampleNullableClientFixture safeModeClient)
     {
-        private readonly SampleNullableClient sampleClient;
-
-        public ScalarTests(SampleNullableClientFixture safeModeClient)
-        {
-            sampleClient = safeModeClient.sampleClient;
-        }
-
-        [Fact]
-        public async Task GetScalar()
-        {
-            var result = await sampleClient
-          .Query
-          .Person()
-          .Select()
-          .ExecuteAsync();
-
-            Assert.NotNull(result.MacAddress);
-            Assert.NotNull(result.Longitude);
-        }
-
-        [Fact]
-        public async Task SetScalar()
-        {
-            var result = await sampleClient
-          .Mutation
-          .UpdatePerson(person: new PersonInput { Name = "Peter", MacAddress = new MacAddress("01-23-45-67-89-ab"), Longitude = new Longitude {  Value = "14° 24' 0\" E" } })
-          .Select()
-          .ExecuteAsync();
-
-
-
-            Assert.NotNull(result);
-        }
-
-
+        sampleClient = safeModeClient.sampleClient;
     }
 
-}
+    [Fact]
+    public async Task GetScalar()
+    {
+        var result = await sampleClient
+            .Query
+            .Person()
+            .Select()
+            .ExecuteAsync();
 
+        Assert.NotNull(result.MacAddress);
+        Assert.NotNull(result.Longitude);
+    }
+
+    [Fact]
+    public async Task SetScalar()
+    {
+        var result = await sampleClient
+            .Mutation
+            .UpdatePerson(new()
+            {
+                Name = "Peter", MacAddress = new("01-23-45-67-89-ab"), Longitude = new() { Value = "14° 24' 0\" E" }
+            })
+            .Select()
+            .ExecuteAsync();
+
+
+        Assert.NotNull(result);
+    }
+}

--- a/test/Linq2GraphQL.Tests/SubscriptionTests.cs
+++ b/test/Linq2GraphQL.Tests/SubscriptionTests.cs
@@ -17,10 +17,7 @@ public class SubscriptionTests : IClassFixture<SampleClientFixture>
         var customerName = "JockeD";
         var customerInput = new CustomerInput
         {
-            CustomerName = customerName,
-            CustomerId = Guid.NewGuid(),
-            Status = CustomerStatus.Active,
-            Orders = new()
+            CustomerName = customerName, CustomerId = Guid.NewGuid(), Status = CustomerStatus.Active, Orders = new()
         };
 
         var subscription = await sampleClient


### PR DESCRIPTION
Replaced Directory.Build.props with Directory.Packages.props to enable centralized package version management. Updated and added package versions as part of the migration.