### PR TITLE
Refactor GraphClient constructor 

### DIFF
--- a/src/Linq2GraphQL.Client/GraphClient.cs
+++ b/src/Linq2GraphQL.Client/GraphClient.cs
@@ -1,6 +1,5 @@
 ﻿using System.Text.Json;
 using System.Text.Json.Serialization;
-using Linq2GraphQL.Client.Converters;
 using Linq2GraphQL.Client.Schema;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,6 +12,11 @@ public class GraphClient
     private readonly IMemoryCache cache;
     private readonly IOptions<GraphClientOptions> options;
     private readonly bool includeDeprecated;
+
+    public GraphClient(HttpClient httpClient, IOptions<GraphClientOptions> options, IServiceProvider provider)
+        : this(httpClient, options, provider, false)
+    {
+    }
 
     public GraphClient(HttpClient httpClient, IOptions<GraphClientOptions> options, IServiceProvider provider, bool includeDeprecated = false)
     {
@@ -38,7 +42,7 @@ public class GraphClient
     public SubscriptionProtocol SubscriptionProtocol => options.Value.SubscriptionProtocol;
     public HttpClient HttpClient { get; }
     public JsonSerializerOptions SerializerOptions { get; }
- 
+
 
     public Func<GraphClient, Task<GraphQLRequest>> WSConnectionInitPayload => options.Value.WSConnectionInitPayload;
     private string GetSubscriptionUrl()
@@ -85,7 +89,7 @@ public class GraphClient
                 query = Helpers.SchemaQuery;
             }
 
-                var graphRequest = new GraphQLRequest { Query = query };
+            var graphRequest = new GraphQLRequest { Query = query };
             return await executor.ExecuteRequestAsync("__schema", graphRequest);
         });
     }

--- a/src/Linq2GraphQL.Generator/ClientGenerator.cs
+++ b/src/Linq2GraphQL.Generator/ClientGenerator.cs
@@ -52,7 +52,7 @@ namespace Linq2GraphQL.Generator
                 query = General.IntrospectionQuery;
             }
 
-                using var response = await httpClient.PostAsJsonAsync(uri, new { query = query });
+            using var response = await httpClient.PostAsJsonAsync(uri, new { query = query });
             if (!response.IsSuccessStatusCode)
             {
                 throw new Exception(
@@ -106,7 +106,7 @@ namespace Linq2GraphQL.Generator
 
             var classInterfacesList = schema.GetClassTypes()?.Where(e => e.HasInterfaces)
                 ?.SelectMany(i => i.Interfaces?.ToDictionary(e => i.Name, e => e.Name))?.ToList() ?? new List<KeyValuePair<string, string>>();
-            
+
             var interfaces = schema.GetInterfaces();
             if (interfaces != null)
             {

--- a/src/Linq2GraphQL.Generator/Linq2GraphQL.Generator.csproj
+++ b/src/Linq2GraphQL.Generator/Linq2GraphQL.Generator.csproj
@@ -6,6 +6,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <PackAsTool>true</PackAsTool>
         <ToolCommandName>Linq2GraphQL</ToolCommandName>
+        <TransformOnBuild>true</TransformOnBuild>
 
 		<Authors>Joakim Dangården, Magnus Ahlberg</Authors>
 		<Company>Linq2GraphQL</Company>


### PR DESCRIPTION
to add an overload for optional includeDeprecated parameter. 
Clean up whitespace in GraphClient and ClientGenerator files for improved readability. 
Update project file to enable TransformOnBuild to avoid forgetting to do that.