### PR TITLE
Added support for newer HCL that does not set descriptions for scalar…

### DIFF
--- a/src/Linq2GraphQL.Generator/Templates/Scalars/ScalarTemplate.cs
+++ b/src/Linq2GraphQL.Generator/Templates/Scalars/ScalarTemplate.cs
@@ -37,10 +37,10 @@ namespace Linq2GraphQL.Generator.Templates.Scalars
             #line default
             #line hidden
             this.Write(";\r\n\r\n    /// <summary>\r\n    /// ");
-            
+
             #line 13 "C:\Data\Linq2GraphQL.Client-1\src\Linq2GraphQL.Generator\Templates\Scalars\ScalarTemplate.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(scalarType.SummaryDescription));
-            
+            this.Write(this.ToStringHelper.ToStringWithCulture(scalarType.SummaryDescription ?? $"Represents the {scalarType.Name} scalar type"));
+
             #line default
             #line hidden
             this.Write("\r\n    /// </summary>\r\n    [JsonConverter(typeof(CustomScalarConverter<");

--- a/src/Linq2GraphQL.Generator/Templates/Scalars/ScalarTemplate.tt
+++ b/src/Linq2GraphQL.Generator/Templates/Scalars/ScalarTemplate.tt
@@ -10,7 +10,7 @@ using System.Text.Json.Serialization;
 namespace <#= namespaceName #>;
 
     /// <summary>
-    /// <#= scalarType.SummaryDescription #>
+    /// <#= scalarType.SummaryDescription ?? $"Represents the {scalarType.ScalarTypeName} scalar type" #>
     /// </summary>
     [JsonConverter(typeof(CustomScalarConverter<<#= className #>>))]
     public partial class <#= className #> : CustomScalar {}


### PR DESCRIPTION
a safe fallback solution when newer HCL does not write description and linq2graphql otherwise fails will null reference error. 