### PR TITLE
Fix typos and replace Console.WriteLine with Debug.WriteLine

### DIFF
--- a/src/Linq2GraphQL.Client/GraphBaseExecute.cs
+++ b/src/Linq2GraphQL.Client/GraphBaseExecute.cs
@@ -14,7 +14,7 @@ public abstract class GraphBaseExecute<T, TResult>
     protected readonly Expression<Func<T, TResult>> selector;
 
     private readonly SemaphoreSlim _lock = new(1, 1);
-    private bool intialized;
+    private bool initialized;
     private GraphQLSchema schema;
 
     public GraphBaseExecute(GraphClient client, OperationType operationType, QueryNode queryNode,
@@ -33,12 +33,12 @@ public abstract class GraphBaseExecute<T, TResult>
         await _lock.WaitAsync();
         try
         {
-            if (!intialized)
+            if (!initialized)
             {
                 schema = await client.GetSchemaForSafeModeAsync();
                 QueryNode.SetAllUniqueVariableNames();
                 QueryNode.AddPrimitiveChildren(true, schema);
-                intialized = true;
+                initialized = true;
             }
 
         }

--- a/src/Linq2GraphQL.Client/GraphClient.cs
+++ b/src/Linq2GraphQL.Client/GraphClient.cs
@@ -67,9 +67,9 @@ public class GraphClient
             return null;
         }
 
-        var cackeKey = "Linq2GraphQL_Schema:" + HttpClient.BaseAddress;
+        var cacheKey = "Linq2GraphQL_Schema:" + HttpClient.BaseAddress;
 
-        return await cache.GetOrCreateAsync(cackeKey, async entry =>
+        return await cache.GetOrCreateAsync(cacheKey, async entry =>
         {
             var executor = new QueryExecutor<GraphQLSchema>(this);
 

--- a/src/Linq2GraphQL.Client/QueryNode.cs
+++ b/src/Linq2GraphQL.Client/QueryNode.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System.Diagnostics;
+using System.Reflection;
 using Linq2GraphQL.Client.Schema;
 
 namespace Linq2GraphQL.Client;
@@ -142,7 +143,7 @@ public class QueryNode
                     }
                     else
                     {
-                        Console.WriteLine(
+                        Debug.WriteLine(
                             $"Property: {propertyInfo.Name} Type: {Member.Name} was not present in active schema");
                     }
                 }


### PR DESCRIPTION
## Summary

- Fix typo: `intialized` → `initialized` in `GraphBaseExecute.cs` (field declaration and two usages)
- Fix typo: `cackeKey` → `cacheKey` in `GraphClient.cs`
- Replace `Console.WriteLine` with `Debug.WriteLine` in `QueryNode.cs` — the SafeMode schema warning should not write to stdout in production applications; `Debug.WriteLine` sends the message to the debug output channel, which is visible during development but silent in release builds

## Changes

| File | Change |
|---|---|
| `GraphBaseExecute.cs` | Rename `intialized` → `initialized` |
| `GraphClient.cs` | Rename `cackeKey` → `cacheKey` |
| `QueryNode.cs` | Replace `Console.WriteLine` with `Debug.WriteLine`, add `using System.Diagnostics` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)