### PR TITLE
Add StatusCode property to GraphQueryRequestException

### DIFF
--- a/src/Linq2GraphQL.Client/Exceptions/GraphQueryRequestException.cs
+++ b/src/Linq2GraphQL.Client/Exceptions/GraphQueryRequestException.cs
@@ -1,14 +1,18 @@
-﻿namespace Linq2GraphQL.Client;
+﻿using System.Net;
+
+namespace Linq2GraphQL.Client;
 
 public class GraphQueryRequestException : Exception
 {
-    public GraphQueryRequestException(string message, string query, Dictionary<string, object> variables) :
+    public GraphQueryRequestException(string message, HttpStatusCode statusCode, string query, Dictionary<string, object> variables) :
         base(message)
     {
+        StatusCode = statusCode;
         GraphQLQuery = query;
         GraphQLVariables = variables;
     }
 
-    public string GraphQLQuery { get; private set; }
-    public Dictionary<string, object> GraphQLVariables { get; private set; }
+    public HttpStatusCode StatusCode { get; }
+    public string GraphQLQuery { get; }
+    public Dictionary<string, object> GraphQLVariables { get; }
 }

--- a/src/Linq2GraphQL.Client/QueryExecutor.cs
+++ b/src/Linq2GraphQL.Client/QueryExecutor.cs
@@ -26,7 +26,7 @@ public class QueryExecutor<T>
         {
             var content = await response.Content.ReadAsStringAsync(cancellationToken);
             throw new GraphQueryRequestException($"Http error! Status code {response.StatusCode} Error: {content}",
-                graphRequest.Query, graphRequest.Variables);
+                response.StatusCode, graphRequest.Query, graphRequest.Variables);
         }
 
         var con = await response.Content.ReadAsStringAsync(cancellationToken);


### PR DESCRIPTION
## Problem

`GraphQueryRequestException` currently embeds the HTTP status code only inside the exception message string:

```csharp
throw new GraphQueryRequestException($"Http error! Status code {response.StatusCode} Error: {content}", ...);
```

This means callers who want to handle specific HTTP errors (e.g. 401 Unauthorized vs 503 Service Unavailable) are forced to parse a string, which is fragile and not idiomatic C#.

## Solution

Add a structured `StatusCode` property of type `HttpStatusCode` to `GraphQueryRequestException`, populated at the throw site in `QueryExecutor`.

Callers can now write clean, type-safe error handling:

```csharp
catch (GraphQueryRequestException ex) when (ex.StatusCode == HttpStatusCode.Unauthorized)
{
    // refresh token and retry
}
catch (GraphQueryRequestException ex) when (ex.StatusCode == HttpStatusCode.ServiceUnavailable)
{
    // back off and retry
}
```

## Changes

| File | Change |
|---|---|
| `GraphQueryRequestException.cs` | Add `HttpStatusCode StatusCode` property and constructor parameter; tighten property accessors to `get`-only |
| `QueryExecutor.cs` | Pass `response.StatusCode` when throwing the exception |

🤖 Generated with [Claude Code](https://claude.com/claude-code)