### PR TITLE
Convert GraphQLRequest and ArgumentValue to record types

### DIFF
--- a/src/Linq2GraphQL.Client/ArgumentValue.cs
+++ b/src/Linq2GraphQL.Client/ArgumentValue.cs
@@ -1,6 +1,6 @@
 ﻿namespace Linq2GraphQL.Client;
 
-public class ArgumentValue
+public record ArgumentValue
 {
     public ArgumentValue(string graphName, string graphType, object value)
     {
@@ -10,8 +10,8 @@ public class ArgumentValue
         VariableName = graphName;
     }
 
-    public string GraphName { get; set; }
-    public string GraphType { get; set; }
-    public object Value { get; set; }
-    public string VariableName { get; set; }
+    public string GraphName { get; init; }
+    public string GraphType { get; init; }
+    public object Value { get; init; }
+    public string VariableName { get; set; } // mutable: unique suffix appended during query building
 }

--- a/src/Linq2GraphQL.Client/GraphQLRequest.cs
+++ b/src/Linq2GraphQL.Client/GraphQLRequest.cs
@@ -2,9 +2,9 @@
 
 namespace Linq2GraphQL.Client;
 
-public class GraphQLRequest
+public record GraphQLRequest
 {
-    [JsonPropertyName("query")] public string Query { get; set; }
+    [JsonPropertyName("query")] public string Query { get; init; }
 
-    [JsonPropertyName("variables")] public Dictionary<string, object> Variables { get; set; }
+    [JsonPropertyName("variables")] public Dictionary<string, object> Variables { get; init; }
 }


### PR DESCRIPTION
## Problem

`GraphQLRequest` and `ArgumentValue` are plain data-transfer objects — they exist solely to hold values with no behaviour. They are currently defined as `class` types, which:

- Allows accidental mutation after construction
- Uses reference equality (two instances with identical data are not equal)
- Requires more boilerplate than necessary

## Solution

Convert both to C# `record` types, which are designed exactly for this purpose.

**`GraphQLRequest`** — fully immutable. Both properties become `init`-only since the object is constructed once and never mutated:

```csharp
// Before
public class GraphQLRequest
{
    public string Query { get; set; }
    public Dictionary<string, object> Variables { get; set; }
}

// After
public record GraphQLRequest
{
    public string Query { get; init; }
    public Dictionary<string, object> Variables { get; init; }
}
```

**`ArgumentValue`** — mostly immutable. `GraphName`, `GraphType`, and `Value` are set at construction and never changed (`init`). `VariableName` remains `set` because the query builder appends a uniqueness suffix to it during query construction — this is noted with a comment.

## Benefits

- **Immutability** — `init`-only properties prevent accidental mutation after construction
- **Value equality** — two instances with identical data compare as equal, which is the natural expectation for DTOs
- **`with` expressions** — callers can cleanly create modified copies: `request with { Query = newQuery }`
- **Better `ToString()`** — records produce a readable representation automatically, useful for debugging

## Compatibility

Both changes are fully backward-compatible. Object initializer syntax (`new GraphQLRequest { Query = ..., Variables = ... }`) works identically with `init` properties.

🤖 Generated with [Claude Code](https://claude.com/claude-code)